### PR TITLE
Fixing the linux run + adding a makefile rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,9 +41,17 @@ docs:
 
 # Run the main class
 .PHONY: run
-run: compile
+run: run-windows
+
+.PHONY: run-windows
+run-windows: compile
 	@echo "Running $(MAIN_CLASS)"
 	powershell.exe -Command "& { java -cp '$(BIN_DIR);$(ASSETS_DIR)' $(MAIN_CLASS) }"
+
+.PHONY: run-linux
+run-linux: compile
+	@echo "Running $(MAIN_CLASS)"
+	java -cp '$(BIN_DIR):$(ASSETS_DIR)' $(MAIN_CLASS)
 
 
 # Clean up generated files

--- a/README.md
+++ b/README.md
@@ -55,32 +55,18 @@ make compile
 
 3. Run the game:
 
-If you're on Windows, the Makefile will work just fine. On Linux, you will need to modify the Makefile as follows:
-
-From : 
-
-```makefile
-# Run the main class
-.PHONY: run
-run: compile
-	@echo "Running $(MAIN_CLASS)"
-	powershell.exe -Command "& { java -cp '$(BIN_DIR);$(ASSETS_DIR)' $(MAIN_CLASS) }"
+If you are using Linux, you can run the game with the following command:
+```
+make run-linux
 ```
 
-To : 
-
-```makefile
-# Run the main class
-.PHONY: run
-run: compile
-	@echo "Running $(MAIN_CLASS)"
-	java -cp '$(BIN_DIR):$(ASSETS_DIR)' $(MAIN_CLASS)
-```
-
-Finally to run the game, use the following command:
-
-
+If you're on Windows, the following command will run the game:
 ```bash
+make run-windows
+```
+
+Alternatively, you can use:
+```
 make run
 ```
 


### PR DESCRIPTION
- Adding the rule `make-linux` in the makefile to run on linux (instead of having to manually edit the file) ;
- Fixing the rule which was provided in the makefile (use colon (`:`) and not semicolon (`;`) on linux to separate the dirs in the classpath) ;
- Changing the README to reflect the changes.